### PR TITLE
Updated session.graphCall to permit POSTting (to allow publishing in addition to reading)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ user. requst.headers are the headers from the server request.
         })(function(result) {
             console.log('Username is:' + result.name);
         });
+        facebook_session.graphCall("/me/feed", {message:"I love node.js!"}, 'POST')(function(result) {
+            console.log('The new feed post id is: ' + result.id);
+        });
     });
     
 A full example may be executed with: `node run_example.js`. Please configure `yourappid`+`yourappsecret` in that file first.
@@ -131,6 +134,8 @@ Calculates the signature for a given set of parameters and the api_secret.
 Changelog
 ---------
 
+- 1.3.0 (2011/03/09)
+  - added method argument to session.graphCall to permit POSTing in addition to GETting
 - 1.2.0 (2011/03/09)
   - added support for node 0.4
 - 1.1.0 (2010/12/29)

--- a/lib/facebook-client/FacebookClient.js
+++ b/lib/facebook-client/FacebookClient.js
@@ -15,7 +15,7 @@ var querystring = require("querystring");
 var FacebookSession = require("./FacebookSession").FacebookSession;
 var FacebookToolkit = require("./FacebookToolkit");
 
-function doRawJsonRequest(host, port, path, secure) {
+function doRequest(host, port, path, secure, method, data, parser) {
     return function(cb) {
         var protocol = http;
         if(secure) protocol = https;
@@ -23,7 +23,7 @@ function doRawJsonRequest(host, port, path, secure) {
             host: host,
             port: port,
             path: path,
-            method: 'GET'
+            method: method || 'GET'
         };
         var request = protocol.request(options, function(response){
             response.setEncoding("utf8");
@@ -35,43 +35,22 @@ function doRawJsonRequest(host, port, path, secure) {
             });
 
             response.on("end", function () {
-                cb(JSON.parse(body.join("")));
+                cb(parser(body.join("")));
             });
         });
-
+        if(data != null) {
+            request.write(querystring.stringify(data))
+        }
         request.end();
     };
 };
+function doRawJsonRequest(host, port, path, secure, method, data) {
+    return doRequest(host, port, path, secure, method, data, JSON.parse);
+};
 
-
-function doRawQueryRequest(host, port, path, secure) {
-    return function(cb) {
-        var protocol = http;
-        if(secure) protocol = https;
-        var options = {
-            host: host,
-            port: port,
-            path: path,
-            method: 'GET'
-        };
-        
-        var request = protocol.request(options, function(response){
-            response.setBodyEncoding("utf8");
-
-            var body = [];
-
-            response.on("data", function (chunk) {
-                body.push(chunk);
-            });
-
-            response.on("end", function () {
-                cb(querystring.parse(body.join("")));
-            });
-        });
-
-        request.end();
-    };
-}
+function doRawQueryRequest(host, port, path, secure, method, data) {
+    return doRequest(host, port, path, secure, method, data, querystring.parse);
+};
 
 var FacebookClient = function(api_key, api_secret, options) {
     var self = this;
@@ -113,17 +92,30 @@ var FacebookClient = function(api_key, api_secret, options) {
         return doRestCall(method, params, access_token);
     };
     
-    this.graphCall = function(path, params) {
+    this.graphCall = function(path, params, method) {
+        /*
+         * Default to take HTTP because it's faster.
+         */
+        var host = self.options.facebook_graph_server_host;
+        var port = self.options.facebook_graph_server_port;
+        var secure = false;
+        var data = null;
+        
         if (params.access_token) {
             /*
              * We have to do a secure request, because the access_token is given. This is HTTPS.
              */
-            return doRawJsonRequest(self.options.facebook_graph_secure_server_host, self.options.facebook_graph_secure_server_port, path + '?' + querystring.stringify(params), true);
+            host = self.options.facebook_graph_secure_server_host;
+            port = self.options.facebook_graph_secure_server_port;
+            secure = true;
         }
-        /*
-         * No access token given, let's take HTTP because it's faster.
-         */
-        return doRawJsonRequest(self.options.facebook_graph_server_host, self.options.facebook_graph_server_port, path + '?' + querystring.stringify(params), false);
+        
+        if (method == 'POST') {
+            data = params;
+        } else {
+            path = path + '?' + querystring.stringify(params);
+        }
+        return doRawJsonRequest(host, port, path, secure, method, data);
     };
     
     this.getAccessToken = function(params) {

--- a/lib/facebook-client/FacebookSession.js
+++ b/lib/facebook-client/FacebookSession.js
@@ -16,7 +16,8 @@ var FacebookSession = function(facebook_client, access_token) {
     
     if (access_token)
     {
-        self.graphCall = function(path, params) {
+        self.graphCall = function(path, params, method) {
+            method = method || 'GET';
             var authed_params = {
                 "access_token": access_token
             };
@@ -25,7 +26,7 @@ var FacebookSession = function(facebook_client, access_token) {
                 authed_params[key] = params[key];
             }
             
-            return self.facebook_client.graphCall(path, authed_params);
+            return self.facebook_client.graphCall(path, authed_params, method);
         };
 
         this.restCall = function(method, params) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name" : "facebook-client",
-    "version": "1.2.0",
+    "version": "1.3.0",
 
     "engines": { "node": ">= 0.4.0" },
 


### PR DESCRIPTION
The API change only adds a new argument to FacebookSession.graphCall to specify the method ('GET' or 'POST', defaulting to 'GET'). The effect is that setting the method to 'POST' enables things such as:

```
facebook_session.graphCall("/me/feed", {message:"I love node.js!"}, 'POST')(function(result) {
    console.log('The new feed post id is: ' + result.id);
});
```

As an aside, along the way I also cleaned up the duplication that existed in FacebookClient.doRawJsonRequest and doRawQueryRequest
