### PR TITLE
Allow getting access token for App Login

### DIFF
--- a/lib/facebook-client/FacebookClient.js
+++ b/lib/facebook-client/FacebookClient.js
@@ -56,19 +56,19 @@ var FacebookClient = function(api_key, api_secret, options) {
     var self = this;
 
     this.options = options || {};
-    
+
     this.options.facebook_graph_server_host = this.options.facebook_graph_server_host || 'graph.facebook.com';
     this.options.facebook_graph_server_port = this.options.facebook_graph_server_port || '80';
     this.options.facebook_graph_secure_server_port = this.options.facebook_graph_secure_server_port || '443';
     this.options.facebook_graph_secure_server_host = this.options.facebook_graph_secure_server_host || 'graph.facebook.com';
-    
+
     this.options.facebook_server_host = this.options.facebook_server_host || 'api.facebook.com';
     this.options.facebook_server_port = this.options.facebook_server_port || '443';
     this.options.facebook_server_path = this.options.facebook_server_path || '/method/';
 
     var doRestCall = function(method, params, access_token) {
         var request_path_array = [self.options.facebook_server_path, method, '?'];
-        
+
         params = params || {};
         params['access_token'] = access_token;
         params['format'] = "json";
@@ -88,14 +88,14 @@ var FacebookClient = function(api_key, api_secret, options) {
             request_path_array.push(encodeURIComponent(params[key]));
         }
         console.log(request_path_array.join(''));
-        
+
         return doRawJsonRequest(self.options.facebook_server_host, self.options.facebook_server_port, request_path_array.join(''), true);
     };
-    
+
     this.restCall = function(method, params, access_token) {
         return doRestCall(method, params, access_token);
     };
-    
+
     this.graphCall = function(path, params, method) {
         /*
          * Default to take HTTP because it's faster.
@@ -104,7 +104,7 @@ var FacebookClient = function(api_key, api_secret, options) {
         var port = self.options.facebook_graph_server_port;
         var secure = false;
         var data = null;
-        
+
         if (params.access_token) {
             /*
              * We have to do a secure request, because the access_token is given. This is HTTPS.
@@ -113,7 +113,7 @@ var FacebookClient = function(api_key, api_secret, options) {
             port = self.options.facebook_graph_secure_server_port;
             secure = true;
         }
-        
+
         if (method == 'POST') {
             data = params;
         } else {
@@ -121,13 +121,14 @@ var FacebookClient = function(api_key, api_secret, options) {
         }
         return doRawJsonRequest(host, port, path, secure, method, data);
     };
-    
+
     this.getAccessToken = function(params) {
         var access_params = {
-                client_id: api_key,
-                client_secret: api_secret
+            client_id: api_key,
+            client_secret: api_secret,
+            grant_type: ''
         };
-        
+
         for (var key in params) {
             access_params[key] = params[key];
         }
@@ -138,7 +139,7 @@ var FacebookClient = function(api_key, api_secret, options) {
             });
         };
     };
-    
+
 };
 
 FacebookClient.prototype.getSessionByAccessToken = function(access_token) {
@@ -160,7 +161,7 @@ FacebookClient.prototype.getSessionByRequestHeaders = function(request_headers) 
             cb();
             return
         }
-        
+
         var facebook_cookie_raw = request_headers["cookie"].match(/fbs_[\d]+\=\"([^; ]+)\"/);
         if (!facebook_cookie_raw)
         {
@@ -170,7 +171,7 @@ FacebookClient.prototype.getSessionByRequestHeaders = function(request_headers) 
             cb();
             return ;
         }
-        
+
         var facebook_cookie = querystring.parse(facebook_cookie_raw[1]);
         if (!facebook_cookie)
         {
@@ -180,7 +181,7 @@ FacebookClient.prototype.getSessionByRequestHeaders = function(request_headers) 
             cb();
             return ;
         }
-        
+
         if (!facebook_cookie['access_token'] || !facebook_cookie['expires']) {
             /*
              * We don't have an access_token nor expires, this won't work.


### PR DESCRIPTION
When trying to get an access token for an [App Login](https://developers.facebook.com/docs/authentication/#applogin), you need to specify a grant_type parameter. The current implementation of the function Facebookclient->getAccessToken doesn't allow that.

This pull request fixes it.
