### PR TITLE
node-facebook-client is broken with signed request

### DIFF
--- a/lib/facebook-client/FacebookClient.js
+++ b/lib/facebook-client/FacebookClient.js
@@ -90,7 +90,7 @@ var FacebookClient = function(app_id, app_secret, options) {
             request_path_array.push(encodeURIComponent(params[key]));
         }
         console.log(request_path_array.join(''));
-        
+
         return doRawJsonRequest(self.options.facebook_server_host, self.options.facebook_server_port, request_path_array.join(''), true);
     };
     
@@ -168,7 +168,7 @@ var FacebookClient = function(app_id, app_secret, options) {
 					cb();
 					return;
 				}
-				return self.getSessionByAccessToken(access_token, user_id)(cb);
+				self.getSessionByAccessToken(access_token, user_id)(cb);
 			});
 		};
 	}

--- a/lib/facebook-client/FacebookClient.js
+++ b/lib/facebook-client/FacebookClient.js
@@ -16,6 +16,34 @@ var querystring = require("querystring");
 var FacebookSession = require("./FacebookSession").FacebookSession;
 var FacebookToolkit = require("./FacebookToolkit");
 
+var persist_dict = {};
+var persist_fifo = [];
+var persist_size = 256 * 256;
+
+function storeAccessTokenById(id, cookie) {
+	cookie['user_id'] = id;
+	var old_cookie = persist_dict[id];
+	if (!old_cookie || parseInt(old_cookie['expires'], 10) <= parseInt(cookie['expires'], 10)) {
+		persist_dict[id] = cookie;
+		persist_fifo.push(cookie);
+	}
+	while (persist_fifo.length > persist_size) {
+		var rm = persist_fifo.shift();
+		if (rm === persist_dict[rm['user_id']])
+			delete persist_dict[rm['user_id']];
+	}
+}
+
+function getAccessTokenById(id) {
+	var cookie = persist_dict[id];
+	if (cookie) {
+		if ((new Date()).getTime() < parseInt(cookie['expires'], 10) * 1000)
+			return null;
+		return cookie;
+	}
+	return null;
+}
+
 function doRequest(host, port, path, secure, method, data, parser) {
     return function(cb) {
         var protocol = http;
@@ -89,7 +117,6 @@ var FacebookClient = function(app_id, app_secret, options) {
             request_path_array.push("=");
             request_path_array.push(encodeURIComponent(params[key]));
         }
-        console.log(request_path_array.join(''));
 
         return doRawJsonRequest(self.options.facebook_server_host, self.options.facebook_server_port, request_path_array.join(''), true);
     };
@@ -142,13 +169,13 @@ var FacebookClient = function(app_id, app_secret, options) {
 		if (!sigs)
 			return null;
 		var encoded_sig = sigs[0], payload = sigs[1];
-		var sig = (new Buffer(encoded_sig.replace('-', '+').replace('_', '/'), 'base64')).toString('binary');
-		var data = JSON.parse((new Buffer(payload.replace('-', '+').replace('_', '/'), 'base64')).toString('utf8'));
+		var sig = (new Buffer(encoded_sig.replace(/\-/g, '+').replace(/\_/g, '/'), 'base64')).toString('hex');
+		var data = JSON.parse((new Buffer(payload.replace(/\-/g, '+').replace(/\_/g, '/'), 'base64')).toString('utf8'));
 		if (!data['algorithm'] || data['algorithm'].toUpperCase() != 'HMAC-SHA256')
 			return null;
 		var hmac = crypto.createHmac('sha256', app_secret);
 		hmac.update(payload);
-		var expected_sig = hmac.digest();
+		var expected_sig = hmac.digest('hex');
 		if (sig != expected_sig)
 			return null;
 		return data;
@@ -168,6 +195,7 @@ var FacebookClient = function(app_id, app_secret, options) {
 					cb();
 					return;
 				}
+				storeAccessTokenById(user_id, {'oauth_token': access_token, 'expires': expires});
 				self.getSessionByAccessToken(access_token, user_id)(cb);
 			});
 		};
@@ -193,6 +221,14 @@ var FacebookClient = function(app_id, app_secret, options) {
 				return;
 			}
 
+			if (facebook_cookie['user_id']) {
+				var access_token = getAccessTokenById(facebook_cookie['user_id']);
+				if (access_token) {
+					facebook_cookie['oauth_token'] = access_token['oauth_token'];
+					facebook_cookie['expires'] = access_token['expires'];
+				}
+			}
+
 			if (facebook_cookie['oauth_token']) {
 				var now = (new Date()).getTime();
 				var expires_time = parseInt(facebook_cookie['expires'], 10) * 1000;
@@ -200,6 +236,7 @@ var FacebookClient = function(app_id, app_secret, options) {
 					cb();
 					return;
 				}
+				storeAccessTokenById(facebook_cookie['user_id'], facebook_cookie);
 				self.getSessionByAccessToken(facebook_cookie['oauth_token'], facebook_cookie['user_id'])(cb);
 			} else if (facebook_cookie['code']) {
 				self.getSessionByOAuthCode(facebook_cookie['code'], '', facebook_cookie['user_id'])(cb);

--- a/lib/facebook-client/FacebookClient.js
+++ b/lib/facebook-client/FacebookClient.js
@@ -7,9 +7,10 @@
  * information, please see the LICENSE file in the root folder.
  */
 
-var sys = require("sys");
 var http = require("http");
 var https = require("https");
+var connect = require("connect");
+var crypto = require("crypto");
 var querystring = require("querystring");
 
 var FacebookSession = require("./FacebookSession").FacebookSession;
@@ -44,6 +45,7 @@ function doRequest(host, port, path, secure, method, data, parser) {
         request.end();
     };
 };
+
 function doRawJsonRequest(host, port, path, secure, method, data) {
     return doRequest(host, port, path, secure, method, data, JSON.parse);
 };
@@ -52,7 +54,7 @@ function doRawQueryRequest(host, port, path, secure, method, data) {
     return doRequest(host, port, path, secure, method, data, querystring.parse);
 };
 
-var FacebookClient = function(api_key, api_secret, options) {
+var FacebookClient = function(app_id, app_secret, options) {
     var self = this;
 
     this.options = options || {};
@@ -71,7 +73,7 @@ var FacebookClient = function(api_key, api_secret, options) {
         
         params = params || {};
         params['access_token'] = access_token;
-        params['format'] = "json";
+        params['format'] = "json-strings";
 
         var is_first = true;
         for (var key in params) {
@@ -105,10 +107,7 @@ var FacebookClient = function(api_key, api_secret, options) {
         var secure = false;
         var data = null;
         
-        if (params.access_token) {
-            /*
-             * We have to do a secure request, because the access_token is given. This is HTTPS.
-             */
+        if (params.access_token) { // We have to do a secure request, because the access_token is given. This is HTTPS.
             host = self.options.facebook_graph_secure_server_host;
             port = self.options.facebook_graph_secure_server_port;
             secure = true;
@@ -122,15 +121,13 @@ var FacebookClient = function(api_key, api_secret, options) {
         return doRawJsonRequest(host, port, path, secure, method, data);
     };
     
-    this.getAccessToken = function(params) {
+    this.getAccessTokenFromCode = function(code, redirect_uri) {
         var access_params = {
-                client_id: api_key,
-                client_secret: api_secret
+                "client_id": app_id,
+                "client_secret": app_secret,
+				"code": code,
+				"redirect_uri": redirect_uri
         };
-        
-        for (var key in params) {
-            access_params[key] = params[key];
-        }
 
         return function(cb) {
             doRawQueryRequest(self.options.facebook_graph_secure_server_host, self.options.facebook_graph_secure_server_port, "/oauth/access_token" + '?' +  querystring.stringify(access_params), true)(function(response) {
@@ -138,70 +135,82 @@ var FacebookClient = function(api_key, api_secret, options) {
             });
         };
     };
-    
+
+	// parse data out of signed request
+	function parseSignedRequest(signed_request) {
+		var sigs = signed_request.split('.', 2);
+		if (!sigs)
+			return null;
+		var encoded_sig = sigs[0], payload = sigs[1];
+		var sig = (new Buffer(encoded_sig.replace('-', '+').replace('_', '/'), 'base64')).toString('binary');
+		var data = JSON.parse((new Buffer(payload.replace('-', '+').replace('_', '/'), 'base64')).toString('utf8'));
+		if (!data['algorithm'] || data['algorithm'].toUpperCase() != 'HMAC-SHA256')
+			return null;
+		var hmac = crypto.createHmac('sha256', app_secret);
+		hmac.update(payload);
+		var expected_sig = hmac.digest();
+		if (sig != expected_sig)
+			return null;
+		return data;
+	}
+
+	this.getSessionByAccessToken = function(access_token, user_id) {
+		return function(cb) {
+			var session = new FacebookSession(self, access_token, user_id);
+			cb(session);
+		};
+	};
+
+	this.getSessionByOAuthCode = function (oauth_code, redirect_uri, user_id) {
+		return function (cb) {
+			self.getAccessTokenFromCode(oauth_code, redirect_uri)(function (access_token, expires) {
+				if (!access_token || (new Date()).getTime() < parseInt(expires, 10) * 1000) { // The token is expired.
+					cb();
+					return;
+				}
+				return self.getSessionByAccessToken(access_token, user_id)(cb);
+			});
+		};
+	}
+
+	this.getSessionByRequestHeaders = function(requestHeaders) {
+		return function(cb) {
+			if (!requestHeaders['cookie']) { // We have not even cookies on this request!
+				cb();
+				return;
+			}
+			var cookie = connect.utils.parseCookie(requestHeaders['cookie']);
+
+			var signed_request = cookie['fbsr_' + app_id];
+			if (!signed_request) { // There is no such thing as a fbsr_ cookie in the request.
+				cb();
+				return;
+			}
+
+			var facebook_cookie = parseSignedRequest(signed_request);
+			if (!facebook_cookie) { // The cookie cannot be parsed.
+				cb();
+				return;
+			}
+
+			if (facebook_cookie['oauth_token']) {
+				var now = (new Date()).getTime();
+				var expires_time = parseInt(facebook_cookie['expires'], 10) * 1000;
+				if (now < expires_time) { // The token is expired.
+					cb();
+					return;
+				}
+				self.getSessionByAccessToken(facebook_cookie['oauth_token'], facebook_cookie['user_id'])(cb);
+			} else if (facebook_cookie['code']) {
+				self.getSessionByOAuthCode(facebook_cookie['code'], '', facebook_cookie['user_id'])(cb);
+			} else { // no way to get access token, abort
+				cb();
+				return;
+			}
+
+		};
+	};
 };
 
-FacebookClient.prototype.getSessionByAccessToken = function(access_token) {
-    var self = this;
-    return function(cb) {
-        var session = new FacebookSession(self, access_token);
-        cb(session);
-    };
-};
-
-FacebookClient.prototype.getSessionByRequestHeaders = function(request_headers) {
-    var self = this;
-    return function(cb) {
-        if (!request_headers['cookie'])
-        {
-            /*
-             * We have not even cookies on this request!
-             */
-            cb();
-            return
-        }
-        
-        var facebook_cookie_raw = request_headers["cookie"].match(/fbs_[\d]+\=\"([^; ]+)\"/);
-        if (!facebook_cookie_raw)
-        {
-            /*
-             * There is no such thing as a fbs_ cookie in the request.
-             */
-            cb();
-            return ;
-        }
-        
-        var facebook_cookie = querystring.parse(facebook_cookie_raw[1]);
-        if (!facebook_cookie)
-        {
-            /*
-             * The cookie cannot be parsed.
-             */
-            cb();
-            return ;
-        }
-        
-        if (!facebook_cookie['access_token'] || !facebook_cookie['expires']) {
-            /*
-             * We don't have an access_token nor expires, this won't work.
-             */
-            cb();
-        }
-
-        var now = new Date();
-        var expires_time = parseInt(facebook_cookie['expires'], 10) * 1000;
-
-        if (now.getTime() < expires_time)
-        {
-            /*
-             * The token is expired.
-             */
-            cb();
-            return ;
-        }
-
-        self.getSessionByAccessToken(facebook_cookie['access_token'])(cb);
-    };
-};
 
 exports.FacebookClient = FacebookClient;

--- a/lib/facebook-client/FacebookSession.js
+++ b/lib/facebook-client/FacebookSession.js
@@ -7,16 +7,11 @@
  * information, please see the LICENSE file in the root folder.
  */
 
-var FacebookSession = function(facebook_client, access_token) {
+var FacebookSession = function(facebook_client, access_token, user_id) {
     var self = this;
 
-    this.facebook_client = facebook_client;
-    
-    this.has_access_token = false;
-    
-    if (access_token)
-    {
-        self.graphCall = function(path, params, method) {
+    if (access_token) {
+        var graphCall = function(path, params, method) {
             method = method || 'GET';
             var authed_params = {
                 "access_token": access_token
@@ -25,51 +20,65 @@ var FacebookSession = function(facebook_client, access_token) {
             for (var key in params) {
                 authed_params[key] = params[key];
             }
-            
-            return self.facebook_client.graphCall(path, authed_params, method);
+            return facebook_client.graphCall(path, authed_params, method);
         };
 
-        this.restCall = function(method, params) {
+        var restCall = function(method, params) {
             return facebook_client.restCall(method, params, access_token);
         };
+
+		this.api = function (path, params, method) {
+			if (typeof path == "object") { // is rest api call
+				return restCall(path['method'], path);
+			} else if (typeof path == "string") {
+				return graphCall(path, params, method);
+			}
+		}
         
-        self.has_access_token = true;
-    }
-    
+        this.has_access_token = true;
+    } else {
+		this.api = function (path, params, method) {
+			if (typeof path == "object") { // is rest api call
+				return facebook_client.restCall(path['method'], path);
+			} else if (typeof path == "string") {
+				return facebook_client.graphCall(path, params, method);
+			}
+		}
+
+		this.has_access_token = false;
+	}
+
     this.getAccessToken = function(options) {
         return facebook_client.getAccessToken(options);
     };
-        
-};
 
-FacebookSession.prototype.getId = function() {
-    var self = this;
-    
-    return function(cb) {
-        if (self.has_access_token) {
-            self.graphCall("/me")(function(user_data){
-                cb(user_data.id);
-            });
-        } else {
-            cb();
-        }
-    }
-}
+	this.getId = function() {
+		return function(cb) {
+			if (self.has_access_token) {
+				if (user_id) {
+					cb(user_id);
+				} else {
+					self.api("/me")(function(user_data){
+						user_id = user_data.id;
+						cb(user_data.id);
+					});
+				}
+			} else {
+				cb();
+			}
+		}
+	}
+};
 
 FacebookSession.prototype.isValid = function() {
     var self = this;
-    
     return function(cb) {
         if (self.has_access_token) {
-            self.graphCall("/me")(function(user_data){
+            self.api("/me")(function(user_data){
                 if (user_data.error)
-                {
                     cb(false);
-                }
                 else
-                {
                     cb(true);
-                }
             });
         } else {
             cb(false);
@@ -78,59 +87,17 @@ FacebookSession.prototype.isValid = function() {
 }
 
 
-FacebookSession.prototype.getMeta = function() {
+FacebookSession.prototype.getUser = function() {
     var self = this;
-    
     return function(cb) {
         if (self.has_access_token) {
-            self.graphCall("/me")(function(user_data){
+            self.api("/me")(function(user_data){
                 cb(user_data);
             });
         } else {
             cb();
         }
     }
-};
-
-FacebookSession.prototype.retrieveAccessToken = function(code, redirect_uri) {
-    var self = this;
-    
-    return function(cb) {
-        self.getAccessToken({
-            redirect_uri: redirect_uri,
-            code: code
-        })(function(access_token, expire_time) {
-            self.injectAccessToken(access_token)(function() {
-                cb();
-            });
-        });
-    }
-};
-
-FacebookSession.prototype.injectAccessToken = function(access_token) {
-    var self = this;
-    
-    return function(cb) {
-        self.graphCall = function(path, params) {
-            var authed_params = {
-                "access_token": access_token
-            };
-            
-            for (var key in params) {
-                authed_params[key] = params[key];
-            }
-            
-            return self.facebook_client.graphCall(path, authed_params);
-        };
-        
-        self.restCall = function(method, params) {
-            return facebook_client.restCall(method, params, access_token);
-        };
-
-        self.has_access_token = true;
-        
-        cb();
-    };
 };
 
 exports.FacebookSession = FacebookSession;

--- a/package.json
+++ b/package.json
@@ -24,13 +24,17 @@
     "bin" : {
     },
 
+	"dependencies" : {
+		"connect": ">= 1.8.5"
+	},
+
     "repository": {
         "type": "git",
         "web": "http://github.com/DracoBlue/node-facebook-client.git"
     },
 
     "bugs": {
-        "web": "http://github.com/DracoBlue/node-facebook-client/issues"
+        "url": "http://github.com/DracoBlue/node-facebook-client/issues"
     },
 
     "licenses" : [


### PR DESCRIPTION
The cookie provided by Facebook now is encrypted, a.k.a. signed request: https://developers.facebook.com/docs/authentication/signed_request/

I've made changes so that it now can correctly parse signed request (fbsr_ cookie). with some minor changes to have similar interface with the official php-sdk.
