### PR TITLE
Configurable timeouts

### DIFF
--- a/lib/facebook-client/FacebookClient.js
+++ b/lib/facebook-client/FacebookClient.js
@@ -16,7 +16,7 @@ var crypto = require("crypto");
 var FacebookSession = require("./FacebookSession").FacebookSession;
 var FacebookToolkit = require("./FacebookToolkit");
 
-function doRequest(host, port, path, secure, method, data, parser) {
+function doRequest(host, port, path, secure, method, data, parser, timeout) {
     return function(cb) {
         var protocol = http;
         if(secure) protocol = https;
@@ -27,8 +27,8 @@ function doRequest(host, port, path, secure, method, data, parser) {
             method: method || 'GET'
         };
         var timed_out = false;
-        var timeout_timer = null;        
-        
+        var timeout_timer = null;
+
         var request = protocol.request(options, function(response){
             response.setEncoding("utf8");
 
@@ -43,23 +43,21 @@ function doRequest(host, port, path, secure, method, data, parser) {
                 {
                     return;
                 }
-                clearTimeout(timeout_timer);                
+                clearTimeout(timeout_timer);
                 cb(parser(body.join("")));
             });
         });
         
-        timeout_timer = setTimeout(function() {
-            timed_out = true;
-            try
-            {
-                request.abort();
-            }
-            catch (error)
-            {
-            }
+        request.on('error', function (error) {
             cb();
-        }, 10000);
-    
+        });
+        
+        if (typeof(timeout) === 'number') {
+            timeout_timer = setTimeout(function() {
+                timed_out = true;
+                request.abort(); //will trigger an 'error' event on request, does not throw exception.                
+            }, timeout);
+        }
         if(data != null)
         {
             request.write(querystring.stringify(data));
@@ -67,12 +65,12 @@ function doRequest(host, port, path, secure, method, data, parser) {
         request.end();
     };
 };
-function doRawJsonRequest(host, port, path, secure, method, data) {
-    return doRequest(host, port, path, secure, method, data, JSON.parse);
+function doRawJsonRequest(host, port, path, secure, method, data, timeout) {
+    return doRequest(host, port, path, secure, method, data, JSON.parse, timeout);
 };
 
-function doRawQueryRequest(host, port, path, secure, method, data) {
-    return doRequest(host, port, path, secure, method, data, querystring.parse);
+function doRawQueryRequest(host, port, path, secure, method, data, timeout) {
+    return doRequest(host, port, path, secure, method, data, querystring.parse, timeout);
 };
 
 var FacebookClient = function(api_key, api_secret, options) {
@@ -89,7 +87,9 @@ var FacebookClient = function(api_key, api_secret, options) {
     this.options.facebook_server_port = this.options.facebook_server_port || '443';
     this.options.facebook_server_path = this.options.facebook_server_path || '/method/';
 
-    var doRestCall = function(method, params, access_token) {
+    this.options.timeout = typeof(this.options.timeout) !== 'number' ? 10000 : this.options.timeout;
+    
+    var doRestCall = function(method, params, access_token, timeout) {
         var request_path_array = [self.options.facebook_server_path, method, '?'];
         
         params = params || {};
@@ -112,14 +112,15 @@ var FacebookClient = function(api_key, api_secret, options) {
         }
         console.log(request_path_array.join(''));
         
-        return doRawJsonRequest(self.options.facebook_server_host, self.options.facebook_server_port, request_path_array.join(''), true);
+        return doRawJsonRequest(self.options.facebook_server_host, self.options.facebook_server_port, request_path_array.join(''), true, null, null, timeout);
     };
     
-    this.restCall = function(method, params, access_token) {
-        return doRestCall(method, params, access_token);
+    this.restCall = function(method, params, access_token, timeout) {
+        timeout = typeof(timeout) !== 'number' ? self.options.timeout : timeout;
+        return doRestCall(method, params, access_token, timeout);
     };
     
-    this.graphCall = function(path, params, method) {
+    this.graphCall = function(path, params, method, timeout) {
         /*
          * Default to take HTTP because it's faster.
          */
@@ -127,6 +128,8 @@ var FacebookClient = function(api_key, api_secret, options) {
         var port = self.options.facebook_graph_server_port;
         var secure = false;
         var data = null;
+        
+        timeout = typeof(timeout) !== 'number' ? self.options.timeout : timeout;
         
         if (params.access_token) {
             /*
@@ -148,7 +151,7 @@ var FacebookClient = function(api_key, api_secret, options) {
         } else {
             path = path + '?' + querystring.stringify(params);
         }
-        return doRawJsonRequest(host, port, path, secure, method, data);
+        return doRawJsonRequest(host, port, path, secure, method, data, timeout);
     };
     
     this.getAccessToken = function(params) {
@@ -160,9 +163,11 @@ var FacebookClient = function(api_key, api_secret, options) {
         for (var key in params) {
             access_params[key] = params[key];
         }
-
+        
+        var timeout = self.options.timeout;
+        
         return function(cb) {
-            doRawQueryRequest(self.options.facebook_graph_secure_server_host, self.options.facebook_graph_secure_server_port, "/oauth/access_token" + '?' +  querystring.stringify(access_params), true)(function(response) {
+            doRawQueryRequest(self.options.facebook_graph_secure_server_host, self.options.facebook_graph_secure_server_port, "/oauth/access_token" + '?' +  querystring.stringify(access_params), true, null, null, timeout)(function(response) {
                 if (!response) {
                     cb();
                 } else {

--- a/lib/facebook-client/FacebookSession.js
+++ b/lib/facebook-client/FacebookSession.js
@@ -13,20 +13,19 @@ var FacebookSession = function(facebook_client, access_token, oauth_code) {
     this.facebook_client = facebook_client;
     this.oauth_code = oauth_code || null;
     
-    this.graphCall = function(path, params, method) {
+    this.graphCall = function(path, params, method, timeout) {
         return function(cb) {
             self.retrieveAccessToken(self.oauth_code, '')(function(access_token) {
                 if (!access_token) {
                     cb();
                     return ;
-                }
-                
-                self.graphCall(path, params, method)(cb);
+                }                
+                self.graphCall(path, params, method, timeout)(cb);
             });
         };
     };
 
-    this.restCall = function(method, params) {
+    this.restCall = function(method, params, timeout) {
         return function(cb) {
             self.retrieveAccessToken(self.oauth_code, '')(function(access_token) {
                 if (!access_token) {
@@ -34,7 +33,7 @@ var FacebookSession = function(facebook_client, access_token, oauth_code) {
                     return ;
                 }
                 
-                self.restCall(method, params, access_token)(cb);
+                self.restCall(method, params, timeout)(cb);
             });
         };
     };
@@ -119,7 +118,7 @@ FacebookSession.prototype.injectAccessToken = function(access_token) {
 FacebookSession.prototype.rawInjectAccessToken = function(access_token) {
     var self = this;
     
-    self.graphCall = function(path, params) {
+    self.graphCall = function(path, params, method, timeout) {
         var authed_params = {
             "access_token": access_token
         };
@@ -128,11 +127,11 @@ FacebookSession.prototype.rawInjectAccessToken = function(access_token) {
             authed_params[key] = params[key];
         }
         
-        return self.facebook_client.graphCall(path, authed_params);
+        return self.facebook_client.graphCall(path, authed_params, method, timeout);
     };
     
-    self.restCall = function(method, params) {
-        return self.facebook_client.restCall(method, params, access_token);
+    self.restCall = function(method, params, timeout) {        
+        return self.facebook_client.restCall(method, params, access_token, timeout);
     };
 };
 


### PR DESCRIPTION
I've added configurable timeout.

This can be set either at a FacebookClient level, by using the timeout property of the options object, or it can also be set individually by restCall or graphCall, setting the last parameter with the timeout value.

I've also changed the way the request.abort() error was behaving, because it was being wrapped in a try/catch clause, but request.abort does not throw exception, it just triggers the 'error' event in the request object. So I listen to that event and then call the callback with empty result.

Let me know if there is something I'm missing or needs to be modified, I've tested it a little bit with the run_example.js and playing with timeout values.

I'm sorry about the extra commits, still learning git.
